### PR TITLE
convert to article ES v3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,6 @@ verify:
 	obt verify
 
 unit-test:
-	mocha tests
+	mocha tests/*
 
 test: verify unit-test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # n-article-branding [![Circle CI](https://circleci.com/gh/Financial-Times/n-article-branding/tree/master.svg?style=svg)](https://circleci.com/gh/Financial-Times/n-article-branding/tree/master)
 
-Gets branding for an article. Branding can either be an article brand or a columnist.
+v2 and upwards is based on V3 ES article metadata.
+
+Returns metadata tag that is corresponds to the brand according to these rules;
+
+1. Brand, if;
+  - has a brand tag
+
+2. Author, if;
+  - has an author tag and
+  - genre = Comment and
+    does not have a brand tag that is not the author
+
+Returned tag is decorated with additional headshot value (it's url) if branding
+is columnist and there is a headshot for that columnist (set in next-es-interface).

--- a/data/headshot-mapping-data.json
+++ b/data/headshot-mapping-data.json
@@ -1,0 +1,148 @@
+{
+  "authors": [
+    {"id": "Q0ItMDAwMDkxOQ==-QXV0aG9ycw==",
+      "name": "Andrew Hill",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "David Tang",
+      "id": "Q0ItMDAwMDQ1NQ==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Edward Luce",
+      "id": "Q0ItMDAwMDgwNQ==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Gideon Rachman",
+      "id": "Q0ItMDAwMDkyOA==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Gillian Tett",
+      "id": "Q0ItMDAwMDg3NA==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Janan Ganesh",
+      "id": "Q0ItMDAxNzEwNg==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Jancis Robinson",
+      "id": "Q0ItMDAwMDI2Mw==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Jo Ellison",
+      "id": "Q0ItMDI1MTU5Mw==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "John Authers",
+      "id": "Q0ItMDAwMDkyMw==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "John Gapper",
+      "id": "Q0ItMDAwMDc1Mw==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Lisa Pollack",
+      "id": "Q0ItMDAwMTY5Nw==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Lucy Kellaway",
+      "id": "Q0ItMDAwMDkyNg==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Martin Wolf",
+      "id": "Q0ItMDAwMDkwMA==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Merryn Somerset Webb",
+      "id": "Q0ItMDAwMDQwMw==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Michael Skapinker",
+      "id": "Q0ItMDMxODc0Mw==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Philip Stephens",
+      "id": "Q0ItMDAwMDkyOQ==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Robert Shrimsley",
+      "id": "Q0ItMDAwMDkyMQ==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Robin Lane Fox",
+      "id": "Q0ItMDAwMDY2MA==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Roula Khalaf",
+      "id": "Q0ItMDAwMDc5NQ==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Rowley Leigh",
+      "id": "Q0ItMDAwMDI5Ng==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Simon Kuper",
+      "id": "Q0ItMDAwMDI2Ng==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Susie Boyt",
+      "id": "Q0ItMDAwMDI5OQ==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Tyler Brûlé",
+      "id": "Q0ItMDAwMDI2NA==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    },
+    {"name": "Wolfgang Münchau",
+      "id": "Q0ItMDAwMTMyMg==-QXV0aG9ycw==",
+      "attributes": [
+        {"key": "hasHeadshot", "value": true}
+      ]
+    }
+  ]
+}

--- a/mappings/headshot-mapping.js
+++ b/mappings/headshot-mapping.js
@@ -1,0 +1,16 @@
+const data = require('../data/headshot-mapping-data');
+
+module.exports = function (tag) {
+
+	if (!tag || !tag.taxonomy || tag.taxonomy !== 'authors') {
+		return;
+	}
+
+	const matchedTag = data.authors.find(author => author.id === tag.idV1);
+
+	if (matchedTag) {
+		tag.attributes = tag.attributes.concat(matchedTag.attributes);
+	}
+
+	return;
+};

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "ft-n-article-branding",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "main": "main.js",
   "devDependencies": {
     "chai": "^3.2.0",
     "mocha": "^2.2.5",
     "npm-prepublish": "^1.2.0",
+    "next-build-tools": "^5.10.0",
     "origami-build-tools": "^4.0.0"
   }
 }

--- a/tests/fixtures/branding/brand.json
+++ b/tests/fixtures/branding/brand.json
@@ -1,0 +1,9 @@
+{
+  "id": "QnJhbmRzXzEwNA==-QnJhbmRz",
+  "name": "Lombard",
+  "url": "/stream/brandId/QnJhbmRzXzEwNA==-QnJhbmRz",
+  "idV1": "QnJhbmRzXzEwNA==-QnJhbmRz",
+  "prefLabel": "Lombard",
+  "taxonomy": "brand",
+  "attributes": []
+}

--- a/tests/fixtures/branding/columnist.json
+++ b/tests/fixtures/branding/columnist.json
@@ -1,0 +1,10 @@
+{
+  "id": "Q0ItMDAwMDg0MA==-QXV0aG9ycw==",
+  "name": "John Gapper",
+  "url": "/stream/authorsId/Q0ItMDAwMDg0MA==-QXV0aG9ycw==",
+  "idV1": "Q0ItMDAwMDg0MA==-QXV0aG9ycw==",
+  "prefLabel": "Tanya Powley",
+  "taxonomy": "authors",
+  "primary": true,
+  "attributes": []
+}

--- a/tests/fixtures/branding/columnistHeadshot.json
+++ b/tests/fixtures/branding/columnistHeadshot.json
@@ -1,0 +1,13 @@
+{
+  "id": "Q0ItMDAwMDc1Mw==-QXV0aG9ycw==",
+  "name": "John Gapper",
+  "url": "/stream/authorsId/Q0ItMDAwMDc1Mw==-QXV0aG9ycw==",
+  "idV1": "Q0ItMDAwMDc1Mw==-QXV0aG9ycw==",
+  "prefLabel": "John Gapper",
+  "taxonomy": "authors",
+  "primary": true,
+  "attributes": [
+    {"key": "hasHeadshot", "value": true}
+  ],
+  "headshot": "https://image.webservices.ft.com/v1/images/raw/fthead:john-gapper"
+}

--- a/tests/fixtures/metadata/brandAndColumnistMetadata.json
+++ b/tests/fixtures/metadata/brandAndColumnistMetadata.json
@@ -1,0 +1,31 @@
+[
+  {
+    "id": "Q0ItMDAwMDc1Mw==-QXV0aG9ycw==",
+    "name": "John Gapper",
+    "url": "/stream/authorsId/Q0ItMDAwMDc1Mw==-QXV0aG9ycw==",
+    "idV1": "Q0ItMDAwMDc1Mw==-QXV0aG9ycw==",
+    "prefLabel": "John Gapper",
+    "taxonomy": "authors",
+    "primary": true,
+    "attributes": []
+  },
+  {
+    "id": "QnJhbmRzXzEwNA==-QnJhbmRz",
+    "name": "Lombard",
+    "url": "/stream/brandId/QnJhbmRzXzEwNA==-QnJhbmRz",
+    "idV1": "QnJhbmRzXzEwNA==-QnJhbmRz",
+    "prefLabel": "Lombard",
+    "taxonomy": "brand",
+    "attributes": []
+  },
+  {
+    "id": "OA==-R2VucmVz",
+    "name": "Comment",
+    "url": "/stream/genreId/OA==-R2VucmVz",
+    "idV1": "OA==-R2VucmVz",
+    "prefLabel": "Comment",
+    "taxonomy": "genre",
+    "primary": false,
+    "attributes": []
+  }
+]

--- a/tests/fixtures/metadata/brandMetadata.json
+++ b/tests/fixtures/metadata/brandMetadata.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "QnJhbmRzXzEwNA==-QnJhbmRz",
+    "name": "Lombard",
+    "url": "/stream/brandId/QnJhbmRzXzEwNA==-QnJhbmRz",
+    "idV1": "QnJhbmRzXzEwNA==-QnJhbmRz",
+    "prefLabel": "Lombard",
+    "taxonomy": "brand",
+    "attributes": []
+  },
+  {
+    "id": "OA==-R2VucmVz",
+    "name": "Comment",
+    "url": "/stream/genreId/OA==-R2VucmVz",
+    "idV1": "OA==-R2VucmVz",
+    "prefLabel": "Comment",
+    "taxonomy": "genre",
+    "attributes": []
+  }
+]

--- a/tests/fixtures/metadata/columnistHasHeadshotMetadata.json
+++ b/tests/fixtures/metadata/columnistHasHeadshotMetadata.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "Q0ItMDAwMDc1Mw==-QXV0aG9ycw==",
+    "name": "John Gapper",
+    "url": "/stream/authorsId/Q0ItMDAwMDc1Mw==-QXV0aG9ycw==",
+    "idV1": "Q0ItMDAwMDc1Mw==-QXV0aG9ycw==",
+    "prefLabel": "John Gapper",
+    "taxonomy": "authors",
+    "primary": true,
+    "attributes": []
+  },
+  {
+    "id": "OA==-R2VucmVz",
+    "name": "Comment",
+    "url": "/stream/genreId/OA==-R2VucmVz",
+    "idV1": "OA==-R2VucmVz",
+    "prefLabel": "Comment",
+    "taxonomy": "genre",
+    "primary": false,
+    "attributes": []
+  }
+]

--- a/tests/fixtures/metadata/columnistMetadata.json
+++ b/tests/fixtures/metadata/columnistMetadata.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "Q0ItMDAwMDg0MA==-QXV0aG9ycw==",
+    "name": "John Gapper",
+    "url": "/stream/authorsId/Q0ItMDAwMDg0MA==-QXV0aG9ycw==",
+    "idV1": "Q0ItMDAwMDg0MA==-QXV0aG9ycw==",
+    "prefLabel": "Tanya Powley",
+    "taxonomy": "authors",
+    "primary": true,
+    "attributes": []
+  },
+  {
+    "id": "OA==-R2VucmVz",
+    "name": "Comment",
+    "url": "/stream/genreId/OA==-R2VucmVz",
+    "idV1": "OA==-R2VucmVz",
+    "prefLabel": "Comment",
+    "taxonomy": "genre",
+    "primary": false,
+    "attributes": []
+  }
+]

--- a/tests/fixtures/metadata/defaultMetadata.json
+++ b/tests/fixtures/metadata/defaultMetadata.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "Nw==-R2VucmVz",
+    "name": "News",
+    "url": "/stream/genreId/Nw==-R2VucmVz",
+    "idV1": "Nw==-R2VucmVz",
+    "prefLabel": "News",
+    "taxonomy": "genre",
+    "attributes": []
+  },
+  {
+    "id": "Q0ItMDAwMDMyNQ==-QXV0aG9ycw==",
+    "name": "James Shotter",
+    "url": "/stream/authorsId/Q0ItMDAwMDMyNQ==-QXV0aG9ycw==",
+    "idV1": "Q0ItMDAwMDMyNQ==-QXV0aG9ycw==",
+    "prefLabel": "James Shotter",
+    "taxonomy": "authors",
+    "attributes": []
+  },
+  {
+    "id": "Q0ItMDAwMTIyNw==-QXV0aG9ycw==",
+    "name": "Jennifer Thompson",
+    "url": "/stream/authorsId/Q0ItMDAwMTIyNw==-QXV0aG9ycw==",
+    "idV1": "Q0ItMDAwMTIyNw==-QXV0aG9ycw==",
+    "prefLabel": "Jennifer Thompson",
+    "taxonomy": "authors",
+    "attributes": []
+  }
+]

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -5,103 +5,35 @@
 const should = require('chai').should();
 const getBranding = require('../main');
 
-const fixtures = {
-	hasBrand: {
-		brand: [{
-			term: {
-				name: 'Lex',
-			}
-		}],
-		tags: [{
-			term: {
-				name: 'Bobby Davro',
-				taxonomy: 'people',
-				attributes: []
-			}
-		}]
-	},
-	hasColumnist: {
-		tags: [
-			{
-				term: {
-					name: 'Bobby Davro',
-					taxonomy: 'people',
-					attributes: []
-				}
-			},
-			{
-				term: {
-					name: 'Martin Wolf',
-					taxonomy: 'people',
-					attributes: [
-						{
-							value: true,
-							key: 'isColumnist'
-						}
-					]
-				}
-			}
-		]
-	},
-	hasBrandAndColumnist: {
-		brand: [{
-			term: {
-				name: 'Lex',
-			}
-		}],
-		tags: [
-			{
-				term: {
-					name: 'Bobby Davro',
-					taxonomy: 'people',
-					attributes: []
-				}
-			},
-			{
-				term: {
-					name: 'Martin Wolf',
-					taxonomy: 'people',
-					attributes: [
-						{
-							value: true,
-							key: 'isColumnist'
-						}
-					]
-				}
-			}
-		]
-	},
-	hasNoBrandOrColumnist: {},
-	hasNoAttributes: {
-		tags: [
-			{
-				term: {
-					name: 'Bobby Davro',
-					taxonomy: 'people'
-				}
-			}
-		]
-	}
-};
+const brandMetadata = require('./fixtures/metadata/brandMetadata');
+const brandAndColumnistMetadata = require('./fixtures/metadata/brandAndColumnistMetadata');
+const columnistMetadata = require('./fixtures/metadata/columnistMetadata');
+const columnistHasHeadshotMetadata = require('./fixtures/metadata/columnistHasHeadshotMetadata');
+const defaultMetadata = require('./fixtures/metadata/defaultMetadata');
+
+const brand = require('./fixtures/branding/brand');
+const columnist = require('./fixtures/branding/columnist');
+const columnistHeadshot = require('./fixtures/branding/columnistHeadshot');
 
 describe('Branding', function () {
 	it('should set branding to the article brand if present', function() {
-		getBranding(fixtures.hasBrand).should.equal(fixtures.hasBrand.brand[0].term);
+		getBranding(brandMetadata).should.eql(brand);
 	});
 
 	it('should set branding to the article columnist if present', function() {
-		getBranding(fixtures.hasColumnist).should.equal(fixtures.hasColumnist.tags[1].term);
+		getBranding(columnistMetadata).should.eql(columnist);
 	});
 
-	it('should set branding to the columnist if both brand and columnist are present', function() {
-		getBranding(fixtures.hasBrandAndColumnist).should.equal(fixtures.hasBrandAndColumnist.tags[1].term);
+	it('should set branding to the brand if both brand (not equal to author) and columnist are present', function() {
+		getBranding(brandAndColumnistMetadata).should.eql(brand);
+	});
+
+	it('should set a headshot to the branding if a columnist and has hasHeadshot attribute', function () {
+		getBranding(columnistHasHeadshotMetadata).should.eql(columnistHeadshot);
 	});
 
 	it('should return null if no brand or columnist is present', function() {
-		should.not.exist(getBranding(fixtures.hasNoBrandOrColumnist));
+		should.not.exist(getBranding(defaultMetadata));
 	});
 
-	it('should return null if a tag has no attributes', function() {
-		should.not.exist(getBranding(fixtures.hasNoAttributes));
-	});
 });

--- a/tests/mappings/headshot-mapping.test.js
+++ b/tests/mappings/headshot-mapping.test.js
@@ -1,0 +1,50 @@
+/*global describe, it*/
+
+require('chai').should();
+const expect = require('chai').expect;
+
+const headshotMapping = require('../../mappings/headshot-mapping');
+
+const headshotAuthorTag = {
+	idV1: "Q0ItMDAxNzEwNg==-QXV0aG9ycw==",
+	name: "Janan Ganesh",
+	taxonomy: "authors",
+	attributes: [ ]
+};
+
+const noHeadshotAuthorTag = {
+	idV1: 'Q0ItSlA4OTc2NQ==-QXV0aG9ycw==',
+  name: 'Jeremy Paxman',
+	attributes: [],
+	taxonomy: 'authors'
+};
+
+const notAuthorTag = {
+  idV1: "OA==-R2VucmVz",
+	name: "Comment",
+	taxonomy: "genre",
+	attributes: [ ]
+};
+
+describe('Mapping author to headshot', function () {
+
+	it('should add attribute of key hasHeadshot with value true for listed authors', function () {
+		headshotMapping(headshotAuthorTag);
+    headshotAuthorTag.attributes[0].should.eql({key: "hasHeadshot", value: true});
+	});
+
+	it('should not amend an author tag with no headshot', function () {
+		headshotMapping(noHeadshotAuthorTag);
+    noHeadshotAuthorTag.attributes.should.be.empty;
+	});
+
+	it('should not amend a tag which does not have taxonomy of author', function () {
+		(headshotMapping(notAuthorTag))
+    notAuthorTag.attributes.should.be.empty;
+	});
+
+	it('should be undefined when no tag is provided', function () {
+		expect(headshotMapping()).to.be.undefined;
+	});
+
+});


### PR DESCRIPTION
Would propose releasing this as v2.0.0

Behaves in same way as v1.0.0, except;
- based on article ES v3
- uses genre === Comment and section === Columnists to determine whether to use author as brand
- adds a headshot value (url) to the returned tag, if columnist and either isColumnist or hasHeadshot are true against the author (use of isColumnist for this purpose should be deprecated once hasHeadshot is propagated through next-es-interface).

(my-ft-page and stream-page are the two apps currently using this and are set at ^v1.0.0)
