### PR TITLE
use new image service

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,7 +26,7 @@ function isGenreComment(metadata) {
 
 function headshotUrl(tag) {
 	const fileName = removeDiacritics(tag.prefLabel).toLowerCase().replace(/(\s|')+/g,'-');
-	return `https://next-geebee.ft.com/image/v1/images/raw/fthead:${fileName}`;
+	return `https://www.ft.com/__origami/service/image/v2/images/raw/fthead:${fileName}`;
 }
 
 module.exports = function (metadata) {

--- a/tests/fixtures/branding/columnistHeadshot.json
+++ b/tests/fixtures/branding/columnistHeadshot.json
@@ -6,5 +6,5 @@
   "attributes": [
     {"key": "hasHeadshot", "value": true}
   ],
-  "headshot": "https://next-geebee.ft.com/image/v1/images/raw/fthead:wolfgang-munchau-webb"
+  "headshot": "https://www.ft.com/__origami/service/image/v2/images/raw/fthead:wolfgang-munchau-webb"
 }


### PR DESCRIPTION
We launched the new image service 6 days ago, I'm currently going around FT projects and helping them migrate to it.

The new Image Service includes a lot of improvements:
- The application is multi-region with failover
- We use stale-on-error and stale-while-revalidate cache extensions to ensure users get stale content if the application errors or has to revalidate an image
- We serve much smaller WebP and JPEG XR images to supported browsers
- We’ve seen a reduction in file size for a large number of image requests
- We’re now serving images over H2